### PR TITLE
SAGE-1622: upgrade to v2.3.0 of RPi support debian package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     ca-certificates=20211016ubuntu0.18.04.1 \
     curl=7.58.0-2ubuntu3.22 \
     gnupg-agent=2.2.4-1ubuntu1.6 \
-    software-properties-common=0.96.24.32.18
+    software-properties-common=0.96.24.32.20
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 RUN add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 
@@ -71,7 +71,7 @@ ARG REQ_PACKAGES_WAGGLE="waggle-common-tools waggle-nodeid waggle-node-hostname 
 #  - python versions match end-system verions
 RUN apt-get update && apt-get install -y \
     python3.6=3.6.9-1~18.04ubuntu1.9 \
-    python3-pip=9.0.1-2.3~ubuntu1.18.04.5
+    python3-pip=9.0.1-2.3~ubuntu1.18.04.6
 RUN mkdir -p /iso/waggle/pip
 COPY required_pip_packages.txt /iso/waggle/pip/
 # - this will download all packages and dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,11 +49,11 @@ RUN cd /iso/pool/contrib; apt-get update && apt-get download -y $REQ_PACKAGES_NV
 # Download the Waggle RPI package that needs to be installed to a separate partition
 RUN mkdir -p /iso/pool/special
 RUN cd /iso/pool/special ; \
-    wget https://github.com/waggle-sensor/waggle-rpi-pxeboot/releases/download/v2.2.0/sage-rpi-pxeboot_2.2.0_all.deb ; \
-    wget https://github.com/waggle-sensor/waggle-rpi-pxeboot/releases/download/v2.2.0/sage-rpi-pxeboot-boot_2.2.0_all.deb ; \
-    wget https://github.com/waggle-sensor/waggle-rpi-pxeboot/releases/download/v2.2.0/sage-rpi-pxeboot-os-usrlibfw_2.2.0_all.deb ; \
-    wget https://github.com/waggle-sensor/waggle-rpi-pxeboot/releases/download/v2.2.0/sage-rpi-pxeboot-os-usrlib_2.2.0_all.deb ; \
-    wget https://github.com/waggle-sensor/waggle-rpi-pxeboot/releases/download/v2.2.0/sage-rpi-pxeboot-os-other_2.2.0_all.deb
+    wget https://github.com/waggle-sensor/waggle-rpi-pxeboot/releases/download/v2.3.0/sage-rpi-pxeboot_2.3.0_all.deb ; \
+    wget https://github.com/waggle-sensor/waggle-rpi-pxeboot/releases/download/v2.3.0/sage-rpi-pxeboot-boot_2.3.0_all.deb ; \
+    wget https://github.com/waggle-sensor/waggle-rpi-pxeboot/releases/download/v2.3.0/sage-rpi-pxeboot-os-usrlibfw_2.3.0_all.deb ; \
+    wget https://github.com/waggle-sensor/waggle-rpi-pxeboot/releases/download/v2.3.0/sage-rpi-pxeboot-os-usrlib_2.3.0_all.deb ; \
+    wget https://github.com/waggle-sensor/waggle-rpi-pxeboot/releases/download/v2.3.0/sage-rpi-pxeboot-os-other_2.3.0_all.deb
 
 # Waggle packages
 RUN cd /iso/pool/contrib; \

--- a/required_deb_packages.txt
+++ b/required_deb_packages.txt
@@ -2,11 +2,11 @@
 ## -----------------------------------------------------------------------------------------------------------
 ## Python
 ## (already in base) python=2.7.15~rc1-1
-# python-pip=9.0.1-2.3~ubuntu1.18.04.5
+# python-pip=9.0.1-2.3~ubuntu1.18.04.6
 # python-click=6.7-3
 # python-setuptools=39.0.1-2
 ## (already in base) python3=3.6.7-1~18.04
-# python3-pip=9.0.1-2.3~ubuntu1.18.04.5
+# python3-pip=9.0.1-2.3~ubuntu1.18.04.6
 # python3-venv=3.6.7-1~18.04
 ## (already in base) python3-click=6.7-3
 # python3-setuptools=39.0.1-2
@@ -16,7 +16,7 @@
 ## (already in base) ca-certificates=20210119~18.04.2
 ## (already in base) curl=7.58.0-2ubuntu3.18
 # gnupg-agent=2.2.4-1ubuntu1.6
-## (already in base) software-properties-common=0.96.24.32.18
+# software-properties-common=0.96.24.32.20
 
 ## Docker itself and requirements
 # docker-ce=5:20.10.12~3-0~ubuntu-bionic
@@ -140,7 +140,7 @@ python3.6-minimal=3.6.9-1~18.04ubuntu1.9
 python3.6-venv=3.6.9-1~18.04ubuntu1.9
 python3-distutils=3.6.9-1~18.04
 python3-lib2to3=3.6.9-1~18.04
-python3-pip=9.0.1-2.3~ubuntu1.18.04.5
+python3-pip=9.0.1-2.3~ubuntu1.18.04.6
 python3-setuptools=39.0.1-2
 python3-venv=3.6.7-1~18.04
 python-asn1crypto=0.24.0-1
@@ -158,8 +158,8 @@ python-markupsafe=1.0-1build1
 python-minimal=2.7.15~rc1-1
 python-netaddr=0.7.19-1
 python-paramiko=2.0.0-1ubuntu1.3
-python-pip=9.0.1-2.3~ubuntu1.18.04.5
-python-pip-whl=9.0.1-2.3~ubuntu1.18.04.5
+python-pip=9.0.1-2.3~ubuntu1.18.04.6
+python-pip-whl=9.0.1-2.3~ubuntu1.18.04.6
 python-pkg-resources=39.0.1-2
 python-pyasn1=0.4.2-3
 python-setuptools=39.0.1-2
@@ -168,6 +168,7 @@ python-yaml=3.12-1build2
 rpcbind=0.2.3-0.6ubuntu0.18.04.4
 smartmontools=6.5+svn4324-1ubuntu0.1
 socat=1.7.3.2-2ubuntu2
+software-properties-common=0.96.24.32.20
 sshfs=2.8-1
 sshuttle=0.78.3-1ubuntu1.1
 tree=1.7.0-5


### PR DESCRIPTION
- fix PxE boot failure of new RPi 4 hardware
- disable unused service cloud-init

(port from wildnode-image a28620835ef823d7024beec13fe4585c786704e8)